### PR TITLE
Validate HTTP port input

### DIFF
--- a/OcrServer/SettingsView.swift
+++ b/OcrServer/SettingsView.swift
@@ -41,6 +41,7 @@ struct SettingsView: View {
                     Section("Server") {
                         SettingsRow(icon: "server.rack", title: "HTTP Port", value: $httpPort)
                             .onTapGesture {
+                                inputPortText = httpPort
                                 showingPortSheet = true
                             }
                     }
@@ -100,10 +101,13 @@ struct SettingsView: View {
                             .fontWeight(.medium)
                         Spacer()
                         Button("Confirm") {
-                            Settings.shared.httpPort = Int(inputPortText) ?? 8000
-                            httpPort = inputPortText
+                            guard let port = validatedHTTPPort else { return }
+                            Settings.shared.httpPort = port
+                            httpPort = String(port)
+                            inputPortText = String(port)
                             showingPortSheet = false
                         }
+                        .disabled(validatedHTTPPort == nil)
                     }
                 }
                 .padding()
@@ -116,6 +120,13 @@ struct SettingsView: View {
         serverManager.restartServer()
     }
     
+    private var validatedHTTPPort: Int? {
+        guard let port = Int(inputPortText.trimmingCharacters(in: .whitespacesAndNewlines)),
+              (1...65535).contains(port) else {
+            return nil
+        }
+        return port
+    }
     
 }
     


### PR DESCRIPTION
  ## Summary

  Validate the HTTP port value before saving it from Settings.

  ## What changed

  - Reject non-numeric port input instead of silently falling back to `8000`
  - Require ports to be in the valid TCP/UDP range: `1...65535`
  - Disable the Confirm button while the entered port is invalid
  - Normalize the saved/displayed value to the validated integer string

  ## Why
<img width="400" alt="Screenshot_1_2_horizontal" src="https://github.com/user-attachments/assets/0f537c78-e91c-46d4-8a9d-7de1047fe863" />

  Previously, the Settings screen accepted invalid values such as negative numbers, `0`, ports above `65535`,
  or non-numeric text. These values could either be saved directly or leave the UI showing a value different
  from what was actually persisted.
